### PR TITLE
Fix: Add networking instructions on readme.md for docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ The easiest way is to run via docker-compose:
 ```
 docker-compose up
 ```
+* Please note that before you can create and start the containers for the first time, you might need to create a default docker network:
+`docker network create blog`
 
 You might need to run the following on your machine if Elasticsearch refuses to run: `sysctl -w vm.max_map_count=262144`.
 


### PR DESCRIPTION
When running `docker-compose up` for the first time, I received the following error: `ERROR: Network blog declared as external, but could not be found. Please create the network manually using "docker network create blog" and try again.`

I solved this by running the suggested command: `docker network create blog`

Screenshot attached:
![Screen Shot 2019-08-17 at 1 15 14](https://user-images.githubusercontent.com/20744388/63201171-be2bb280-c08c-11e9-933b-f09083652079.png)
